### PR TITLE
Removed hard coded paths and compilers from graphitc.py

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,18 @@ set(PYTHON_SOURCE_FILES ./test/python/test.py)
 #add_executable(PYTHON_TEST ${PYTHON_SOURCE_FILES})
 #target_link_libraries(PYTHON_TEST ${PYTHON_LIBRARIES})
 
-configure_file(src/graphitc.py ${CMAKE_BINARY_DIR}/bin/graphitc.py COPYONLY)
+#configure_file(src/graphitc.py ${CMAKE_BINARY_DIR}/bin/graphitc.py COPYONLY)
+set(GRAPHITC_PY
+	"${CMAKE_BINARY_DIR}/bin/graphitc.py"
+)
+add_custom_command(OUTPUT ${GRAPHITC_PY}
+	COMMAND sed -e s?CXX_COMPILER_PLACEHOLDER?${CMAKE_CXX_COMPILER}?g -e s?GRAPHIT_SOURCE_DIRECTORY_PLACEHOLDER?${CMAKE_SOURCE_DIR}?g -e s?GRAPHIT_BUILD_DIRECTORY_PLACEHOLDER?${CMAKE_BINARY_DIR}?g ${CMAKE_SOURCE_DIR}/src/graphitc.py > ${GRAPHITC_PY}
+	DEPENDS ${CMAKE_SOURCE_DIR}/src/graphitc.py
+	VERBATIM
+)
+
+add_custom_target(copy_graphitc_py ALL DEPENDS ${GRAPHITC_PY})
+
 configure_file(src/main.cpp ${CMAKE_BINARY_DIR}/bin/main.cpp COPYONLY)
 
 add_executable(bfs_verifier ./test/verifiers/bfs_verifier.cpp)

--- a/src/graphitc.py
+++ b/src/graphitc.py
@@ -3,13 +3,20 @@ import unittest
 import subprocess
 import os
 
+CXX_COMPILER="CXX_COMPILER_PLACEHOLDER"
+GRAPHIT_BUILD_DIRECTORY="GRAPHIT_BUILD_DIRECTORY_PLACEHOLDER".strip().rstrip('/')
+GRAPHIT_SOURCE_DIRECTORY="GRAPHIT_SOURCE_DIRECTORY_PLACEHOLDER".strip().rstrip('/')
+
+
+
+
 def parseArgs():
     parser = argparse.ArgumentParser(description='compiling graphit files')
     parser.add_argument('-f', dest = 'input_file_name')
     parser.add_argument('-o', dest = 'output_file_name')
     parser.add_argument('-a', dest = 'input_algo_file_name')
-    parser.add_argument('-i', dest = 'runtime_include_path', default = '../../include/')
-    parser.add_argument('-l', dest = 'graphitlib_path', default = '../lib/libgraphitlib.a')
+    parser.add_argument('-i', dest = 'runtime_include_path', default = GRAPHIT_SOURCE_DIRECTORY+'/include/')
+    parser.add_argument('-l', dest = 'graphitlib_path', default = GRAPHIT_BUILD_DIRECTORY+'/lib/libgraphitlib.a')
     args = parser.parse_args()
     return vars(args)
 
@@ -73,6 +80,6 @@ if __name__ == '__main__':
     # compile and execute compile.cpp file to complete the compilation
     #TODO: code here uses very fragile relavtive paths, figure out a better way
     # Maybe setting environment variables
-    subprocess.check_call("g++ -g -std=c++11 -I {0} {1} -o compile.o {2}".format(runtime_include_path, compile_file_name, graphitlib_path), shell=True)
+    subprocess.check_call(CXX_COMPILER + " -g -std=c++11 -I {0} {1} -o compile.o {2}".format(runtime_include_path, compile_file_name, graphitlib_path), shell=True)
     subprocess.check_call("./compile.o  -f " + algo_file_name +  " -o " + output_file_name, shell=True)
     #subprocess.check_call("g++ -g -std=c++11 -I ../../src/runtime_lib/  " + output_file_name + " -o test.o", shell=True)


### PR DESCRIPTION
This is a fix to the main problem in #76 
The graphitc.py was always invoking g++ while creating the compiler using the user provided schedule. g++ may not be available or might not be compatible with the compiler used to build the library. Changed to use the compiler from cmake. 

