### PR TITLE
Added a bool flag needs_allocation that keeps track if a VarDecl need…

### DIFF
--- a/include/graphit/midend/mir.h
+++ b/include/graphit/midend/mir.h
@@ -500,7 +500,8 @@ namespace graphit {
             std::string name;
             Type::Ptr type;
             Expr::Ptr initVal;
-
+            //field to keep track of whether the variable needs allocation. Used only for vectors
+            bool needs_allocation = true;
             typedef std::shared_ptr<VarDecl> Ptr;
 
             virtual void accept(MIRVisitor *visitor) {

--- a/src/backend/codegen_cpp.cpp
+++ b/src/backend/codegen_cpp.cpp
@@ -401,7 +401,8 @@ namespace graphit {
                     if (type->element_type != nullptr) {
                         //genPropertyArrayImplementationWithInitialization(constant);
                         //genPropertyArrayDecl(constant);
-                        genPropertyArrayAlloc(constant);
+			if (constant->needs_allocation)
+	                        genPropertyArrayAlloc(constant);
                     }
                 } else if (std::dynamic_pointer_cast<mir::VertexSetType>(constant->type)) {
                     // if the constant is a vertex set  decl

--- a/src/midend/vector_op_lower.cpp
+++ b/src/midend/vector_op_lower.cpp
@@ -47,7 +47,9 @@ namespace  graphit {
                         }
 
                         //insert another const var decl as the temporary holder for the function
+			//this vector is always going to be assigned a value (pointer) returned from the function call and hence does not need allocation
                         auto tmp_var_decl = std::make_shared<mir::VarDecl>();
+			tmp_var_decl->needs_allocation = false;
                         tmp_var_decl->type = var_decl->type;
                         tmp_var_decl->initVal = orig_init_val;
                         tmp_var_decl->name = "generated_tmp_vector_" + mir_context_->getUniqueNameCounterString();


### PR DESCRIPTION
…s explicit allocation

This is for avoiding overallocation of vectors created to hold the return values from function calls while lowering initializations to constants. 