### PR TITLE
Python bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,10 @@ script:
         - cd bin 
         - ./graphit_test
         - cd ..
-        - python python_tests/test.py
-        - python python_tests/test_with_schedules.py
+        - python --version
+        - python3 --version
+        - python3 python_tests/test.py
+        - python3 python_tests/test_with_schedules.py
         - export PYTHONPATH=.
         - python3 python_tests/pybind_test.py
 

--- a/include/graphit/backend/codegen_cpp.h
+++ b/include/graphit/backend/codegen_cpp.h
@@ -123,8 +123,10 @@ namespace graphit {
         void genScalarDecl(mir::VarDecl::Ptr var_decl);
 
         void genScalarAlloc(mir::VarDecl::Ptr shared_ptr);
+
+        void genTypesRequiringTypeDefs();
 	
-	void generatePyBindWrapper(mir::FuncDecl::Ptr);
+	    void generatePyBindWrapper(mir::FuncDecl::Ptr);
 
     	void generatePyBindModule();
 

--- a/include/graphit/midend/mir_context.h
+++ b/include/graphit/midend/mir_context.h
@@ -78,6 +78,10 @@ namespace graphit {
                 return extern_functions_map_[name];
             }
 
+            void addTypeRequiringTypeDef(mir::Type::Ptr type){
+                types_requiring_typedef.push_back(type);
+            }
+
             void addSymbol(mir::Var var) {
                 symbol_table_.insert(var.getName(), var);
             }
@@ -361,6 +365,8 @@ namespace graphit {
             std::map<std::string, std::map<std::string, mir::MergeReduceField::Ptr>> edgeset_to_label_to_merge_reduce;
 
             std::set<std::string> defined_types;
+
+            std::vector<mir::Type::Ptr> types_requiring_typedef;
 
         };
 

--- a/src/backend/codegen_cpp.cpp
+++ b/src/backend/codegen_cpp.cpp
@@ -11,7 +11,7 @@ namespace graphit {
         genEdgeSets();
         //genElementData();
         genStructTypeDecls();
-
+        genTypesRequiringTypeDefs();
 
         //Processing the constants, generting declartions
         for (auto constant : mir_context_->getLoweredConstants()) {
@@ -1450,6 +1450,25 @@ namespace graphit {
         } else {
             //If it is a GraphIt generated function, then we need to instantiate the functor
             return func_name + "()";
+        }
+    }
+
+    void CodeGenCPP::genTypesRequiringTypeDefs() {
+
+        for (mir::Type::Ptr type : mir_context_->types_requiring_typedef){
+            if(mir::isa<mir::VectorType>(type)){
+                auto vector_type = mir::to<mir::VectorType>(type);
+                int range = vector_type->range_indexset;
+                std::string typedef_name = vector_type->toString();
+                if (mir_context_->defined_types.find(typedef_name) == mir_context_->defined_types.end()){
+                    mir_context_->defined_types.insert(typedef_name);
+                    //first generates a typedef for the vector type
+                    oss << "typedef ";
+                    vector_type->vector_element_type->accept(this);
+                    oss << typedef_name <<  " ";
+                    oss << "[ " << range << "]; " << std::endl;
+                }
+            }
         }
     }
 }

--- a/src/midend/mir_emitter.cpp
+++ b/src/midend/mir_emitter.cpp
@@ -206,6 +206,12 @@ namespace graphit {
 
         //element of a vector can be a non-scalar (vector type)
         mir_vector_type->vector_element_type = emitType(ND_tensor_type->blockType);
+        if (mir::isa<mir::VectorType>(mir_vector_type->vector_element_type)){
+            //if each vector_element is a vector (nested vector type, such as vector{Vertex}(vector[5])
+            ctx->addTypeRequiringTypeDef(mir_vector_type->vector_element_type);
+        }
+
+
         if (ND_tensor_type->indexSets.size() == 1 &&
                 fir::isa<fir::RangeIndexSet>(ND_tensor_type->indexSets[0])){
             auto range_index_set = fir::to<fir::RangeIndexSet>(ND_tensor_type->indexSets[0]);

--- a/src/python/graphit.py
+++ b/src/python/graphit.py
@@ -10,8 +10,13 @@ GRAPHIT_BUILD_DIRECTORY="${GRAPHIT_BUILD_DIRECTORY}".strip().rstrip("/")
 GRAPHIT_SOURCE_DIRECTORY="${GRAPHIT_SOURCE_DIRECTORY}".strip().rstrip("/")
 CXX_COMPILER="${CXX_COMPILER}".strip().rstrip("/")
 
+PARALLEL_NONE=0
+PARALLEL_CILK=1
+PARALLEL_OPENMP=2
+
 module_so_list = []
-def compile_and_load(graphit_source_file, extern_cpp_files=[], linker_args=[]):
+
+def compile_and_load(graphit_source_file, extern_cpp_files=[], linker_args=[], parallelization_type=PARALLEL_NONE):
 	graphit_source_file = os.path.expanduser(graphit_source_file.strip())
 	# Obtain a unique filename for the module
 	#module_file = tempfile.NamedTemporaryFile()
@@ -34,6 +39,11 @@ def compile_and_load(graphit_source_file, extern_cpp_files=[], linker_args=[]):
 	compile_command = CXX_COMPILER + " -I" + pybind11.get_include() + " $(python3-config --includes) -c -I " +  GRAPHIT_SOURCE_DIRECTORY + "/src/runtime_lib/ -std=c++11 -DGEN_PYBIND_WRAPPERS -flto -fno-fat-lto-objects -fPIC -fvisibility=hidden "	
 	# now compile the file into .so
 
+	if parallelization_type == PARALLEL_CILK:
+		compile_command += " -DCILK -fcilkplus "
+	elif parallelization_type == PARALLEL_OPENMP:
+		compile_command += " -DOPENMP -fopenmp "
+	
 	try:
 		subprocess.check_call(compile_command + module_filename_cpp + " -o " + module_filename_object, shell=True)
 	except subprocess.CalledProcessError as e:
@@ -53,7 +63,12 @@ def compile_and_load(graphit_source_file, extern_cpp_files=[], linker_args=[]):
 	# append the python3 ldflag if it is macOS, don't need it for Linux
 	if platform.system() == "Darwin":
 		cmd = cmd + "-undefined dynamic_lookup"
-        
+	
+	if parallelization_type == PARALLEL_CILK:
+		cmd += " -fcilkplus "
+	elif parallelization_type == PARALLEL_OPENMP:
+		cmd += " -fopenmp "
+	        
 	if len(linker_args) > 0:
 		cmd += " " + " ".join(linker_args) + " "
 	subprocess.check_call(cmd, shell=True)

--- a/src/python/graphit.py
+++ b/src/python/graphit.py
@@ -23,12 +23,13 @@ def compile_and_load(graphit_source_file, extern_cpp_files=[], linker_args=[], p
 	#module_filename_base = module_file.name
 	#module_file.close()
 	module_filename_base = os.path.splitext(graphit_source_file)[0]
+	module_name = os.path.basename(module_filename_base)	
+	module_filename_base = "/tmp/" + module_name
 
 	# compile the file into a cpp file
 	module_filename_cpp = module_filename_base + ".cpp"
 	module_filename_object = module_filename_base + ".o"
 	module_filename_so = module_filename_base + ".so"
-	module_name = os.path.basename(module_filename_base)	
 
 	try:
 		subprocess.check_call("python " + GRAPHIT_BUILD_DIRECTORY + "/bin/graphitc.py -f " + graphit_source_file + " -o " + module_filename_cpp + " -m " + module_name, stderr=subprocess.STDOUT, shell=True)
@@ -75,7 +76,6 @@ def compile_and_load(graphit_source_file, extern_cpp_files=[], linker_args=[], p
 	spec = importlib.util.spec_from_file_location(module_name, module_filename_so)
 	module = importlib.util.module_from_spec(spec)
 	spec.loader.exec_module(module)
-	os.unlink(module_filename_cpp)
 	os.unlink(module_filename_object)
 	for extern_object in extern_objects:
 		os.unlink(extern_object)

--- a/test/c++/backend_test.cpp
+++ b/test/c++/backend_test.cpp
@@ -866,3 +866,32 @@ TEST_F(BackendTest, edgesetApplyExtern) {
                      "func main() edges.apply(UDF_updateEdge); end");
     EXPECT_EQ (0, basicTest(is));
 }
+
+
+TEST_F(BackendTest, vectorPerVertexTestNoConstDef) {
+    istringstream is("element Vertex end\n"
+                     "element Edge end\n"
+                     "const edges : edgeset{Edge}(Vertex,Vertex) = load (argv[1]);\n"
+                     "const vertices : vertexset{Vertex} = edges.getVertices();\n"
+                     "export func foo(v: vector{Vertex}(vector[20](int)))\n"
+                     "      for i in 0:20\n"
+                     "            print v[i][i];\n"
+                     "      end\n"
+                     "end");
+    EXPECT_EQ (0, basicTest(is));
+}
+
+
+TEST_F(BackendTest, vectorPerVertexTestWithConstDef) {
+    istringstream is("element Vertex end\n"
+                     "element Edge end\n"
+                     "const edges : edgeset{Edge}(Vertex,Vertex) = load (argv[1]);\n"
+                     "const vertices : vertexset{Vertex} = edges.getVertices();\n"
+                     "const v: vector{Vertex}(vector[20](int));\n"
+                     "export func foo(v: vector{Vertex}(vector[20](int)))\n"
+                     "      for i in 0:20\n"
+                     "            print v[i][i];\n"
+                     "      end\n"
+                     "end");
+    EXPECT_EQ (0, basicTest(is));
+}

--- a/test/c++/test.cpp
+++ b/test/c++/test.cpp
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
 //    ::testing::GTEST_FLAG(filter) = "BackendTest.VectorVertexProperty";
 //
 //    ::testing::GTEST_FLAG(filter) = "BackendTest.EdgeSetExportFuncVectorInit";
-//    ::testing::GTEST_FLAG(filter) = "BackendTest.SimpleVertexsetFilterComplete";
+//    ::testing::GTEST_FLAG(filter) = "BackendTest.vectorPerVertexTestWithConstDef";
 //    ::testing::GTEST_FLAG(filter) = "RuntimeLibTest.SimpleLoadGraphFromFileTest";
 //    ::testing::GTEST_FLAG(filter) = "RuntimeLibTest.*";
 //

--- a/test/python/test.py
+++ b/test/python/test.py
@@ -51,6 +51,19 @@ class TestGraphitCompiler(unittest.TestCase):
             os.remove(self.executable_file_name)
 
     # utilities for setting up tests
+    def get_command_output(self, command):
+        output = ""
+        if isinstance(command, list):
+            proc = subprocess.Popen(command, stdout=subprocess.PIPE)
+        else:
+            proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
+        proc.wait()
+        for line in proc.stdout.readlines():
+            if isinstance(line, bytes):
+                line = line.decode()
+            output += line.rstrip() + "\n"
+        proc.stdout.close()
+        return output
 
     def basic_compile_test(self, input_file_name):
         # "-f" and "-o" must not have space in the string, otherwise it doesn't read correctly
@@ -80,7 +93,6 @@ class TestGraphitCompiler(unittest.TestCase):
         self.assertEqual(subprocess.call(graphit_compile_cmd), 0)
         # check if g++ compilation succeeded
         cpp_compile_cmd = [self.cpp_compiler, self.compile_flags, "-I", self.include_path , self.output_file_name, "-o", self.executable_file_name] + extra_cpp_args
-        print cpp_compile_cmd
         self.assertEqual(
             subprocess.call(cpp_compile_cmd),
             0)
@@ -101,10 +113,10 @@ class TestGraphitCompiler(unittest.TestCase):
 
     def expect_output_val(self, input_file_name, expected_output_val, extra_cpp_args=[], extra_exec_args=[]):
         self.basic_compile_exec_test(input_file_name, extra_cpp_args, extra_exec_args)
-        proc = subprocess.Popen(["./"+ self.executable_file_name] + extra_exec_args, stdout=subprocess.PIPE)
+        #proc = subprocess.Popen(["./"+ self.executable_file_name] + extra_exec_args, stdout=subprocess.PIPE)
+        output = self.get_command_output(["./"+ self.executable_file_name]+extra_exec_args).split("\n")[0]
         #check the value printed to stdout is as expected
-        output = proc.stdout.readline()
-
+        #output = proc.stdout.readline()
         print ("output: " + str(output.strip()))
         self.assertEqual(float(output.strip()), expected_output_val)
 
@@ -201,7 +213,7 @@ class TestGraphitCompiler(unittest.TestCase):
 
 
     def test_astar_distance_loader(self):
-	self.expect_output_val("astar_distance_loader.gt", 203845, [self.root_test_input_dir + "astar_distance_loader.cpp"], [GRAPHIT_SOURCE_DIRECTORY + "/test/graphs/monaco.bin"])
+        self.expect_output_val("astar_distance_loader.gt", 203845, [self.root_test_input_dir + "astar_distance_loader.cpp"], [GRAPHIT_SOURCE_DIRECTORY + "/test/graphs/monaco.bin"])
 
     def test_outdegree_sum(self):
         self.basic_compile_exec_test("outdegree_sum.gt")
@@ -220,9 +232,13 @@ class TestGraphitCompiler(unittest.TestCase):
 
     def test_pagerank_cmdline_arg_expect(self):
         self.basic_compile_test("pagerank_with_filename_arg.gt")
-        proc = subprocess.Popen("./"+ self.executable_file_name + " "+GRAPHIT_SOURCE_DIRECTORY+"/test/graphs/test.el", shell=True, stdout=subprocess.PIPE)
+        #proc = subprocess.Popen("./"+ self.executable_file_name + " "+GRAPHIT_SOURCE_DIRECTORY+"/test/graphs/test.el", shell=True, stdout=subprocess.PIPE)
+        #proc.wait()
         #check the value printed to stdout is as expected
-        output = proc.stdout.readline()
+        #output = proc.stdout.readline()
+        #proc.stdout.close()
+        output = self.get_command_output("./"+ self.executable_file_name + " "+GRAPHIT_SOURCE_DIRECTORY+"/test/graphs/test.el")
+        output = output.split("\n")[0]
         print ("output: " + output.strip())
         self.assertEqual(float(output.strip()), 0.00289518)
 
@@ -258,19 +274,22 @@ class TestGraphitCompiler(unittest.TestCase):
         #     print line.rstrip()
 
         # invoke the BFS verifier
-        proc = subprocess.Popen("./bin/bfs_verifier -f "+GRAPHIT_SOURCE_DIRECTORY+"/test/graphs/4.el -t verifier_input -r 8", stdout=subprocess.PIPE, shell=True)
+        #proc = subprocess.Popen("./bin/bfs_verifier -f "+GRAPHIT_SOURCE_DIRECTORY+"/test/graphs/4.el -t verifier_input -r 8", stdout=subprocess.PIPE, shell=True)
+        #proc.wait()
         test_flag = False
-        for line in iter(proc.stdout.readline,''):
+        output = self.get_command_output("./bin/bfs_verifier -f "+GRAPHIT_SOURCE_DIRECTORY+"/test/graphs/4.el -t verifier_input -r 8")
+        for line in output.rstrip().split("\n"):
              if line.rstrip().find("SUCCESSFUL") != -1:
                  test_flag = True
                  break;
+        #proc.stdout.close()
         self.assertEqual(test_flag, True)
 
     def test_simple_atoi(self):
         self.basic_compile_test("simple_atoi.gt")	
         cmd = "./" + self.executable_file_name + " 150 170"
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
-        output = proc.stdout.readline().strip()
+        #oproc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+        output = self.get_command_output(cmd)
         print ("output: " + str(output))
         self.assertEqual(int(output), 320)
 
@@ -296,7 +315,7 @@ class TestGraphitCompiler(unittest.TestCase):
         self.basic_compile_exec_test("sssp.gt")
 
     def test_sssp_delete(self):
-	self.basic_compile_exec_test("sssp_with_delete.gt")
+        self.basic_compile_exec_test("sssp_with_delete.gt")
 
     def test_sssp_verified(self):
         self.basic_compile_test("sssp.gt")
@@ -307,9 +326,10 @@ class TestGraphitCompiler(unittest.TestCase):
         #     print line.rstrip()
 
         # invoke the SSSP verifier
-        proc = subprocess.Popen("./bin/sssp_verifier -f "+GRAPHIT_SOURCE_DIRECTORY+"/test/graphs/4.wel -t verifier_input -r 0", stdout=subprocess.PIPE, shell=True)
+        #proc = subprocess.Popen("./bin/sssp_verifier -f "+GRAPHIT_SOURCE_DIRECTORY+"/test/graphs/4.wel -t verifier_input -r 0", stdout=subprocess.PIPE, shell=True)
+        output = self.get_command_output("./bin/sssp_verifier -f "+GRAPHIT_SOURCE_DIRECTORY+"/test/graphs/4.wel -t verifier_input -r 0")
         test_flag = False
-        for line in iter(proc.stdout.readline,''):
+        for line in output.rstrip().split("\n"):
             if line.rstrip().find("SUCCESSFUL"):
                 test_flag = True
         self.assertEqual(test_flag, True)
@@ -323,9 +343,10 @@ class TestGraphitCompiler(unittest.TestCase):
         #     print line.rstrip()
 
         # invoke the SSSP verifier
-        proc = subprocess.Popen("./bin/sssp_verifier -f "+GRAPHIT_SOURCE_DIRECTORY+"/test/graphs/4.wel -t verifier_input -r 0", stdout=subprocess.PIPE, shell=True)
+        #proc = subprocess.Popen("./bin/sssp_verifier -f "+GRAPHIT_SOURCE_DIRECTORY+"/test/graphs/4.wel -t verifier_input -r 0", stdout=subprocess.PIPE, shell=True)
+        output = self.get_command_output("./bin/sssp_verifier -f "+GRAPHIT_SOURCE_DIRECTORY+"/test/graphs/4.wel -t verifier_input -r 0")
         test_flag = False
-        for line in iter(proc.stdout.readline,''):
+        for line in output.rstrip().split("\n"):
             if line.rstrip().find("SUCCESSFUL"):
                 test_flag = True
         self.assertEqual(test_flag, True)
@@ -334,9 +355,10 @@ class TestGraphitCompiler(unittest.TestCase):
         self.basic_compile_test("cc.gt")
         cmd = "./" + self.executable_file_name + " > verifier_input"
         subprocess.call(cmd, shell=True)
-        proc = subprocess.Popen("./bin/cc_verifier -f "+GRAPHIT_SOURCE_DIRECTORY+"/test/graphs/4.el -t verifier_input -r 1", stdout=subprocess.PIPE, shell=True)
+        #proc = subprocess.Popen("./bin/cc_verifier -f "+GRAPHIT_SOURCE_DIRECTORY+"/test/graphs/4.el -t verifier_input -r 1", stdout=subprocess.PIPE, shell=True)
+        output = self.get_command_output("./bin/cc_verifier -f "+GRAPHIT_SOURCE_DIRECTORY+"/test/graphs/4.el -t verifier_input -r 1")
         test_flag = False
-        for line in iter(proc.stdout.readline,''):
+        for line in output.rstrip().split("\n"):
             if line.rstrip().find("SUCCESSFUL") != -1:
                 test_flag = True
                 break
@@ -345,23 +367,23 @@ class TestGraphitCompiler(unittest.TestCase):
     def test_argv_safe(self):
         self.basic_compile_test("simple_atoi.gt")
         cmd = "./" + self.executable_file_name + " 150 170"
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
-        output = proc.stdout.readline().strip()
+        #proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+        output = self.get_command_output(cmd).strip()
         print ("output: " + str(output))
         self.assertEqual(int(output), 320)
 
     def test_argv_safe_fail(self):
         self.basic_compile_test("simple_atoi.gt")
         cmd = "./" + self.executable_file_name + " 1"
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
-        output = proc.stdout.readline().strip()
+        #proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+        output = self.get_command_output(cmd).strip()
         print ("output: " + str(output))
         self.assertEqual(output, "Error: Did not provide argv[2] as part of the command line input")
 
         self.basic_compile_test("argv_safe.gt")
         cmd = "./" + self.executable_file_name + " 1 2 3"
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
-        output = proc.stdout.readline().strip()
+        #proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+        output = self.get_command_output(cmd).strip()
         print ("output: " + str(output))
         self.assertEqual(output, "Error: Did not provide argv[4] as part of the command line input")
 


### PR DESCRIPTION
1. Changed all the test scripts to use python3 instead of python2. 
2. Abstracted all the calls to subprocess.Popen followed by process.stdout.readline into a common function. 
3. Creates cpp files from the graphit.py module into the /tmp directory. 
Other small bug fixes