### PR TITLE
adding MIR and backend support for boolean operators

### DIFF
--- a/include/graphit/backend/codegen_cpp.h
+++ b/include/graphit/backend/codegen_cpp.h
@@ -65,7 +65,7 @@ namespace graphit {
         virtual void visit(mir::NegExpr::Ptr);
         virtual void visit(mir::EqExpr::Ptr);
 
-        virtual void visit(mir::AndExpr::Ptr);
+	virtual void visit(mir::AndExpr::Ptr);
         virtual void visit(mir::OrExpr::Ptr);
         virtual void visit(mir::XorExpr::Ptr);
         virtual void visit(mir::NotExpr::Ptr);
@@ -129,7 +129,7 @@ namespace graphit {
         void genScalarAlloc(mir::VarDecl::Ptr shared_ptr);
 
         void genTypesRequiringTypeDefs();
-
+	
 	    void generatePyBindWrapper(mir::FuncDecl::Ptr);
 
     	void generatePyBindModule();

--- a/include/graphit/backend/codegen_cpp.h
+++ b/include/graphit/backend/codegen_cpp.h
@@ -65,6 +65,10 @@ namespace graphit {
         virtual void visit(mir::NegExpr::Ptr);
         virtual void visit(mir::EqExpr::Ptr);
 
+        virtual void visit(mir::AndExpr::Ptr);
+        virtual void visit(mir::OrExpr::Ptr);
+        virtual void visit(mir::XorExpr::Ptr);
+        virtual void visit(mir::NotExpr::Ptr);
 
         virtual void visit(mir::MulExpr::Ptr);
         virtual void visit(mir::DivExpr::Ptr);
@@ -125,7 +129,7 @@ namespace graphit {
         void genScalarAlloc(mir::VarDecl::Ptr shared_ptr);
 
         void genTypesRequiringTypeDefs();
-	
+
 	    void generatePyBindWrapper(mir::FuncDecl::Ptr);
 
     	void generatePyBindModule();

--- a/include/graphit/midend/mir.h
+++ b/include/graphit/midend/mir.h
@@ -575,7 +575,7 @@ namespace graphit {
 
         struct FuncDecl : public MIRNode {
             enum class Type {INTERNAL, EXPORTED, EXTERNAL};
-
+ 
             std::string name;
             std::vector<mir::Var> args;
             mir::Var result;
@@ -1078,7 +1078,7 @@ namespace graphit {
             virtual MIRNode::Ptr cloneNode();
         };
 
-        struct AndExpr : public BinaryExpr {
+	struct AndExpr : public BinaryExpr {
             typedef std::shared_ptr<AndExpr> Ptr;
 
             virtual void accept(MIRVisitor *visitor) {

--- a/include/graphit/midend/mir.h
+++ b/include/graphit/midend/mir.h
@@ -575,7 +575,7 @@ namespace graphit {
 
         struct FuncDecl : public MIRNode {
             enum class Type {INTERNAL, EXPORTED, EXTERNAL};
- 
+
             std::string name;
             std::vector<mir::Var> args;
             mir::Var result;
@@ -1070,6 +1070,60 @@ namespace graphit {
 
             virtual void accept(MIRVisitor *visitor) {
                 visitor->visit(self<EqExpr>());
+            }
+
+        protected:
+            virtual void copy(MIRNode::Ptr);
+
+            virtual MIRNode::Ptr cloneNode();
+        };
+
+        struct AndExpr : public BinaryExpr {
+            typedef std::shared_ptr<AndExpr> Ptr;
+
+            virtual void accept(MIRVisitor *visitor) {
+                visitor->visit(self<AndExpr>());
+            }
+
+        protected:
+            virtual void copy(MIRNode::Ptr);
+
+            virtual MIRNode::Ptr cloneNode();
+        };
+
+        struct OrExpr : public BinaryExpr {
+            typedef std::shared_ptr<OrExpr> Ptr;
+
+            virtual void accept(MIRVisitor *visitor) {
+                visitor->visit(self<OrExpr>());
+            }
+
+        protected:
+            virtual void copy(MIRNode::Ptr);
+
+            virtual MIRNode::Ptr cloneNode();
+        };
+
+        struct XorExpr : public BinaryExpr {
+            typedef std::shared_ptr<XorExpr> Ptr;
+
+            virtual void accept(MIRVisitor *visitor) {
+                visitor->visit(self<XorExpr>());
+            }
+
+        protected:
+            virtual void copy(MIRNode::Ptr);
+
+            virtual MIRNode::Ptr cloneNode();
+        };
+
+        struct NotExpr : public Expr {
+            Expr::Ptr operand;
+
+            typedef std::shared_ptr<NotExpr> Ptr;
+
+            virtual void accept(MIRVisitor *visitor) {
+                visitor->visit(self<NotExpr>());
             }
 
         protected:

--- a/include/graphit/midend/mir_emitter.h
+++ b/include/graphit/midend/mir_emitter.h
@@ -84,7 +84,7 @@ namespace graphit {
             virtual void visit(fir::NegExpr::Ptr);
             virtual void visit(fir::EqExpr::Ptr);
 
-            virtual void visit(fir::AndExpr::Ptr);
+	    virtual void visit(fir::AndExpr::Ptr);
             virtual void visit(fir::OrExpr::Ptr);
             virtual void visit(fir::XorExpr::Ptr);
             virtual void visit(fir::NotExpr::Ptr);
@@ -133,3 +133,4 @@ namespace graphit {
 }
 
 #endif //GRAPHIT_MIR_EMITTER_H
+

--- a/include/graphit/midend/mir_emitter.h
+++ b/include/graphit/midend/mir_emitter.h
@@ -84,6 +84,10 @@ namespace graphit {
             virtual void visit(fir::NegExpr::Ptr);
             virtual void visit(fir::EqExpr::Ptr);
 
+            virtual void visit(fir::AndExpr::Ptr);
+            virtual void visit(fir::OrExpr::Ptr);
+            virtual void visit(fir::XorExpr::Ptr);
+            virtual void visit(fir::NotExpr::Ptr);
 
             virtual void visit(fir::MulExpr::Ptr);
             virtual void visit(fir::DivExpr::Ptr);
@@ -129,4 +133,3 @@ namespace graphit {
 }
 
 #endif //GRAPHIT_MIR_EMITTER_H
-

--- a/include/graphit/midend/mir_rewriter.h
+++ b/include/graphit/midend/mir_rewriter.h
@@ -89,6 +89,15 @@ namespace graphit {
             virtual void visit(std::shared_ptr<EqExpr>);
 
 
+            virtual void visit(std::shared_ptr<AndExpr>);
+
+            virtual void visit(std::shared_ptr<OrExpr>);
+
+            virtual void visit(std::shared_ptr<XorExpr>);
+
+            virtual void visit(std::shared_ptr<NotExpr>);
+            
+
             virtual void visit(std::shared_ptr<AddExpr>);
 
             virtual void visit(std::shared_ptr<SubExpr>);

--- a/include/graphit/midend/mir_visitor.h
+++ b/include/graphit/midend/mir_visitor.h
@@ -64,6 +64,11 @@ namespace graphit {
         struct VectorAllocExpr;
 
 
+        struct AndExpr;
+        struct OrExpr;
+        struct XorExpr;
+        struct NotExpr;
+
         struct VarExpr;
         struct MulExpr;
         struct DivExpr;
@@ -142,6 +147,11 @@ namespace graphit {
             virtual void visit(std::shared_ptr<VarExpr>){};
             virtual void visit(std::shared_ptr<EdgeSetLoadExpr>);
 
+
+            virtual void visit(std::shared_ptr<AndExpr>);
+            virtual void visit(std::shared_ptr<OrExpr>);
+            virtual void visit(std::shared_ptr<XorExpr>);
+            virtual void visit(std::shared_ptr<NotExpr>);
 
             virtual void visit(std::shared_ptr<NegExpr>);
             virtual void visit(std::shared_ptr<EqExpr>);

--- a/src/backend/codegen_cpp.cpp
+++ b/src/backend/codegen_cpp.cpp
@@ -84,7 +84,7 @@ namespace graphit {
 		}
 	}
 	dedent();
-	oss << "}" << std::endl;
+	oss << "}" << std::endl;		
 
 	oss << "#endif" << std::endl;
     }
@@ -93,15 +93,15 @@ namespace graphit {
         oss << "#include <vector>" << std::endl;
 	oss << "#include <algorithm>" << std::endl;
         oss << "#include \"intrinsics.h\"" << std::endl;
-
+	
 	oss << "#ifdef GEN_PYBIND_WRAPPERS" << std::endl;
 	oss << "#include <pybind11/pybind11.h>" << std::endl;
 	oss << "#include <pybind11/stl.h>" << std::endl;
 	oss << "#include <pybind11/numpy.h>" << std::endl;
 	oss << "namespace py = pybind11;" << std::endl;
 	oss << "#endif" << std::endl;
-
-
+	
+	
     }
 
     void CodeGenCPP::visit(mir::ForStmt::Ptr for_stmt) {
@@ -202,7 +202,7 @@ namespace graphit {
             assign_stmt->lhs->accept(this);
             oss << "  = ____graphit_tmp_out; "  << std::endl;
 
-        } else
+        } else 
 */
         if (mir::isa<mir::EdgeSetApplyExpr>(assign_stmt->expr)) {
             printIndent();
@@ -332,7 +332,7 @@ namespace graphit {
             var_decl->type->accept(this);
             oss << var_decl->name << "  = ____graphit_tmp_out; " << std::endl;
 
-        } else
+        } else 
 */
         if (mir::isa<mir::EdgeSetApplyExpr>(var_decl->initVal)) {
             printIndent();
@@ -366,7 +366,7 @@ namespace graphit {
             else
                 oss << "void ";
             oss << func_decl->name << " (";
-
+            
             bool printDelimiter = false;
             for (auto arg : func_decl->args) {
                 if (printDelimiter) {
@@ -587,20 +587,20 @@ namespace graphit {
     void CodeGenCPP::generatePyBindWrapper(mir::FuncDecl::Ptr func_decl) {
 	    oss << "#ifdef GEN_PYBIND_WRAPPERS" << std::endl;
 	    oss << "//PyBind Wrappers for function" << func_decl->name << std::endl;
-	    //Currently we do no support, returning Graph Types. So return type can be directly emitted without extra checks
+	    //Currently we do no support, returning Graph Types. So return type can be directly emitted without extra checks	
 	    if (func_decl->result.isInitialized())
 		    if (mir::isa<mir::VectorType>(func_decl->result.getType())) {
 
 		        mir::VectorType::Ptr vector_type = mir::to<mir::VectorType>(func_decl->result.getType());
 			oss << "py::array_t<";
 
-			if (mir::isa<mir::VectorType>(vector_type->vector_element_type))
+			if (mir::isa<mir::VectorType>(vector_type->vector_element_type)) 
 				mir::to<mir::VectorType>(vector_type->vector_element_type)->vector_element_type->accept(this);
-			else
+			else 
 				vector_type->vector_element_type->accept(this);
 			oss << "> ";
 		    }
-		    else
+		    else 
 		        func_decl->result.getType()->accept(this);
 	    else
 		    oss << "void ";
@@ -622,11 +622,11 @@ namespace graphit {
 				    oss << "py::array_t<";
                                     inner_vector_type->vector_element_type->accept(this);
                                     oss << ">";
-                                    oss << " _" << arg.getName();
-			    }else {
+                                    oss << " _" << arg.getName(); 
+			    }else { 
 				    oss << "py::array_t<";
 				    vector_type->vector_element_type->accept(this);
-				    oss << ">";
+				    oss << ">";	
 				    oss << " _" << arg.getName();
 			    }
 		    }else {
@@ -637,7 +637,7 @@ namespace graphit {
 	    }
 	    if (!printDelimiter)
 		    oss << "void";
-	    oss << ") ";
+	    oss << ") ";	
 	    oss << "{ " << std::endl;
 	    indent();
 	    // Need to generate translation for graph arguments before the actual call
@@ -649,7 +649,7 @@ namespace graphit {
 				   printIndent();
 				   oss << "py::array_t<";
 				   type->weight_type->accept(this);
-				   oss << "> " << arg.getName() << "__data = _" << arg.getName() << ".attr(\"data\").cast<py::array_t<";
+				   oss << "> " << arg.getName() << "__data = _" << arg.getName() << ".attr(\"data\").cast<py::array_t<"; 
 				   type->weight_type->accept(this);
 				   oss << ">>();" << std::endl;
 
@@ -660,8 +660,8 @@ namespace graphit {
 				    printIndent();
 				    arg.getType()->accept(this);
 				    oss << arg.getName() << " = builtin_loadWeightedEdgesFromCSR(";
-				    oss << arg.getName() << "__data.data(), " << arg.getName() << "__indptr.data(), " << arg.getName() << "__indices.data(), " << arg.getName() << "__indptr.size()-1, " << arg.getName() << "__indices.size());" << std::endl;
-			    } else {
+				    oss << arg.getName() << "__data.data(), " << arg.getName() << "__indptr.data(), " << arg.getName() << "__indices.data(), " << arg.getName() << "__indptr.size()-1, " << arg.getName() << "__indices.size());" << std::endl; 
+			    } else {	
 				    //Prepare the individual arrays from the object
 				    printIndent();
 				    oss << "py::array_t<int> " << arg.getName() << "__data = _" << arg.getName() << ".attr(\"data\").cast<py::array_t<int>>();" << std::endl;
@@ -672,23 +672,23 @@ namespace graphit {
 				    printIndent();
 				    arg.getType()->accept(this);
 				    oss << arg.getName() << " = builtin_loadEdgesFromCSR(";
-				    oss << arg.getName() << "__indptr.data(), " << arg.getName() << "__indices.data(), " << arg.getName() << "__indptr.size()-1, " << arg.getName() << "__indices.size());" << std::endl;
+				    oss << arg.getName() << "__indptr.data(), " << arg.getName() << "__indices.data(), " << arg.getName() << "__indptr.size()-1, " << arg.getName() << "__indices.size());" << std::endl; 
 			    }
-
+			
 		    } else if (mir::isa<mir::VectorType>(arg.getType())) {
 			    mir::VectorType::Ptr vector_type = mir::to<mir::VectorType>(arg.getType());
 			    printIndent();
 			    vector_type->accept(this);
 			    oss << " " << arg.getName() << " = (";
 			    vector_type->accept(this);
-			    oss << ")_" << arg.getName() << ".data();" << std::endl;
+			    oss << ")_" << arg.getName() << ".data();" << std::endl; 
 		    }
 
 	    }
 	    printIndent();
-
+		
 	    if (func_decl->result.isInitialized()) {
-
+		    
 		    func_decl->result.getType()->accept(this);
 		    oss << "__" << func_decl->result.getName() << " = ";
 	    }
@@ -705,8 +705,8 @@ namespace graphit {
 		    printDelimiter = true;
 	    }
 	    oss << ");" << std::endl;
-	    // We do no support returning Graph types. But we can return still return vectors
-	    if (func_decl->result.isInitialized() ) {
+	    // We do no support returning Graph types. But we can return still return vectors	    
+	    if (func_decl->result.isInitialized() ) { 
 		    if (mir::isa<mir::VectorType>(func_decl->result.getType())) {
 			    mir::VectorType::Ptr vector_type = mir::to<mir::VectorType>(func_decl->result.getType());
 			    // Handle separately if vector of vector
@@ -732,8 +732,8 @@ namespace graphit {
 				    oss << ") }, (";
 				    inner_vector_type->vector_element_type->accept(this);
 				    oss << "*)__" << func_decl->result.getName() << ");" << std::endl;
-
-
+				
+				    
 			    } else   {
 				    // Create the return object
 				    printIndent();
@@ -751,9 +751,9 @@ namespace graphit {
 				    }
 				    oss << "}, { sizeof(";
 				    vector_type->vector_element_type->accept(this);
-				    oss << ") }, __" << func_decl->result.getName() << ");" << std::endl;
+				    oss << ") }, __" << func_decl->result.getName() << ");" << std::endl; 
 			    }
-
+			    
 		    } else {
 		            printIndent();
 			    func_decl->result.getType()->accept(this);
@@ -764,7 +764,7 @@ namespace graphit {
 	    if (func_decl->result.isInitialized()) {
 		    printIndent();
 		    oss << "return " << func_decl->result.getName() << ";" << std::endl;
-	    }
+	    }		
 	    dedent();
 	    printIndent();
 	    oss << "}" << std::endl;

--- a/src/backend/codegen_cpp.cpp
+++ b/src/backend/codegen_cpp.cpp
@@ -84,7 +84,7 @@ namespace graphit {
 		}
 	}
 	dedent();
-	oss << "}" << std::endl;		
+	oss << "}" << std::endl;
 
 	oss << "#endif" << std::endl;
     }
@@ -93,15 +93,15 @@ namespace graphit {
         oss << "#include <vector>" << std::endl;
 	oss << "#include <algorithm>" << std::endl;
         oss << "#include \"intrinsics.h\"" << std::endl;
-	
+
 	oss << "#ifdef GEN_PYBIND_WRAPPERS" << std::endl;
 	oss << "#include <pybind11/pybind11.h>" << std::endl;
 	oss << "#include <pybind11/stl.h>" << std::endl;
 	oss << "#include <pybind11/numpy.h>" << std::endl;
 	oss << "namespace py = pybind11;" << std::endl;
 	oss << "#endif" << std::endl;
-	
-	
+
+
     }
 
     void CodeGenCPP::visit(mir::ForStmt::Ptr for_stmt) {
@@ -202,7 +202,7 @@ namespace graphit {
             assign_stmt->lhs->accept(this);
             oss << "  = ____graphit_tmp_out; "  << std::endl;
 
-        } else 
+        } else
 */
         if (mir::isa<mir::EdgeSetApplyExpr>(assign_stmt->expr)) {
             printIndent();
@@ -332,7 +332,7 @@ namespace graphit {
             var_decl->type->accept(this);
             oss << var_decl->name << "  = ____graphit_tmp_out; " << std::endl;
 
-        } else 
+        } else
 */
         if (mir::isa<mir::EdgeSetApplyExpr>(var_decl->initVal)) {
             printIndent();
@@ -366,7 +366,7 @@ namespace graphit {
             else
                 oss << "void ";
             oss << func_decl->name << " (";
-            
+
             bool printDelimiter = false;
             for (auto arg : func_decl->args) {
                 if (printDelimiter) {
@@ -587,20 +587,20 @@ namespace graphit {
     void CodeGenCPP::generatePyBindWrapper(mir::FuncDecl::Ptr func_decl) {
 	    oss << "#ifdef GEN_PYBIND_WRAPPERS" << std::endl;
 	    oss << "//PyBind Wrappers for function" << func_decl->name << std::endl;
-	    //Currently we do no support, returning Graph Types. So return type can be directly emitted without extra checks	
+	    //Currently we do no support, returning Graph Types. So return type can be directly emitted without extra checks
 	    if (func_decl->result.isInitialized())
 		    if (mir::isa<mir::VectorType>(func_decl->result.getType())) {
 
 		        mir::VectorType::Ptr vector_type = mir::to<mir::VectorType>(func_decl->result.getType());
 			oss << "py::array_t<";
 
-			if (mir::isa<mir::VectorType>(vector_type->vector_element_type)) 
+			if (mir::isa<mir::VectorType>(vector_type->vector_element_type))
 				mir::to<mir::VectorType>(vector_type->vector_element_type)->vector_element_type->accept(this);
-			else 
+			else
 				vector_type->vector_element_type->accept(this);
 			oss << "> ";
 		    }
-		    else 
+		    else
 		        func_decl->result.getType()->accept(this);
 	    else
 		    oss << "void ";
@@ -622,11 +622,11 @@ namespace graphit {
 				    oss << "py::array_t<";
                                     inner_vector_type->vector_element_type->accept(this);
                                     oss << ">";
-                                    oss << " _" << arg.getName(); 
-			    }else { 
+                                    oss << " _" << arg.getName();
+			    }else {
 				    oss << "py::array_t<";
 				    vector_type->vector_element_type->accept(this);
-				    oss << ">";	
+				    oss << ">";
 				    oss << " _" << arg.getName();
 			    }
 		    }else {
@@ -637,7 +637,7 @@ namespace graphit {
 	    }
 	    if (!printDelimiter)
 		    oss << "void";
-	    oss << ") ";	
+	    oss << ") ";
 	    oss << "{ " << std::endl;
 	    indent();
 	    // Need to generate translation for graph arguments before the actual call
@@ -649,7 +649,7 @@ namespace graphit {
 				   printIndent();
 				   oss << "py::array_t<";
 				   type->weight_type->accept(this);
-				   oss << "> " << arg.getName() << "__data = _" << arg.getName() << ".attr(\"data\").cast<py::array_t<"; 
+				   oss << "> " << arg.getName() << "__data = _" << arg.getName() << ".attr(\"data\").cast<py::array_t<";
 				   type->weight_type->accept(this);
 				   oss << ">>();" << std::endl;
 
@@ -660,8 +660,8 @@ namespace graphit {
 				    printIndent();
 				    arg.getType()->accept(this);
 				    oss << arg.getName() << " = builtin_loadWeightedEdgesFromCSR(";
-				    oss << arg.getName() << "__data.data(), " << arg.getName() << "__indptr.data(), " << arg.getName() << "__indices.data(), " << arg.getName() << "__indptr.size()-1, " << arg.getName() << "__indices.size());" << std::endl; 
-			    } else {	
+				    oss << arg.getName() << "__data.data(), " << arg.getName() << "__indptr.data(), " << arg.getName() << "__indices.data(), " << arg.getName() << "__indptr.size()-1, " << arg.getName() << "__indices.size());" << std::endl;
+			    } else {
 				    //Prepare the individual arrays from the object
 				    printIndent();
 				    oss << "py::array_t<int> " << arg.getName() << "__data = _" << arg.getName() << ".attr(\"data\").cast<py::array_t<int>>();" << std::endl;
@@ -672,23 +672,23 @@ namespace graphit {
 				    printIndent();
 				    arg.getType()->accept(this);
 				    oss << arg.getName() << " = builtin_loadEdgesFromCSR(";
-				    oss << arg.getName() << "__indptr.data(), " << arg.getName() << "__indices.data(), " << arg.getName() << "__indptr.size()-1, " << arg.getName() << "__indices.size());" << std::endl; 
+				    oss << arg.getName() << "__indptr.data(), " << arg.getName() << "__indices.data(), " << arg.getName() << "__indptr.size()-1, " << arg.getName() << "__indices.size());" << std::endl;
 			    }
-			
+
 		    } else if (mir::isa<mir::VectorType>(arg.getType())) {
 			    mir::VectorType::Ptr vector_type = mir::to<mir::VectorType>(arg.getType());
 			    printIndent();
 			    vector_type->accept(this);
 			    oss << " " << arg.getName() << " = (";
 			    vector_type->accept(this);
-			    oss << ")_" << arg.getName() << ".data();" << std::endl; 
+			    oss << ")_" << arg.getName() << ".data();" << std::endl;
 		    }
 
 	    }
 	    printIndent();
-		
+
 	    if (func_decl->result.isInitialized()) {
-		    
+
 		    func_decl->result.getType()->accept(this);
 		    oss << "__" << func_decl->result.getName() << " = ";
 	    }
@@ -705,8 +705,8 @@ namespace graphit {
 		    printDelimiter = true;
 	    }
 	    oss << ");" << std::endl;
-	    // We do no support returning Graph types. But we can return still return vectors	    
-	    if (func_decl->result.isInitialized() ) { 
+	    // We do no support returning Graph types. But we can return still return vectors
+	    if (func_decl->result.isInitialized() ) {
 		    if (mir::isa<mir::VectorType>(func_decl->result.getType())) {
 			    mir::VectorType::Ptr vector_type = mir::to<mir::VectorType>(func_decl->result.getType());
 			    // Handle separately if vector of vector
@@ -732,8 +732,8 @@ namespace graphit {
 				    oss << ") }, (";
 				    inner_vector_type->vector_element_type->accept(this);
 				    oss << "*)__" << func_decl->result.getName() << ");" << std::endl;
-				
-				    
+
+
 			    } else   {
 				    // Create the return object
 				    printIndent();
@@ -751,9 +751,9 @@ namespace graphit {
 				    }
 				    oss << "}, { sizeof(";
 				    vector_type->vector_element_type->accept(this);
-				    oss << ") }, __" << func_decl->result.getName() << ");" << std::endl; 
+				    oss << ") }, __" << func_decl->result.getName() << ");" << std::endl;
 			    }
-			    
+
 		    } else {
 		            printIndent();
 			    func_decl->result.getType()->accept(this);
@@ -764,7 +764,7 @@ namespace graphit {
 	    if (func_decl->result.isInitialized()) {
 		    printIndent();
 		    oss << "return " << func_decl->result.getName() << ";" << std::endl;
-	    }		
+	    }
 	    dedent();
 	    printIndent();
 	    oss << "}" << std::endl;
@@ -940,6 +940,36 @@ namespace graphit {
             expr->operands[i + 1]->accept(this);
             oss << ")";
         }
+    }
+
+    void CodeGenCPP::visit(mir::AndExpr::Ptr expr) {
+        oss << '(';
+        expr->lhs->accept(this);
+        oss << " && ";
+        expr->rhs->accept(this);
+        oss << ')';
+    };
+
+    void CodeGenCPP::visit(mir::OrExpr::Ptr expr) {
+        oss << '(';
+        expr->lhs->accept(this);
+        oss << " || ";
+        expr->rhs->accept(this);
+        oss << ')';
+    };
+
+    void CodeGenCPP::visit(mir::XorExpr::Ptr expr) {
+        oss << '(';
+        expr->lhs->accept(this);
+        oss << " ^ ";
+        expr->rhs->accept(this);
+        oss << ')';
+    };
+
+    void CodeGenCPP::visit(mir::NotExpr::Ptr not_expr) {
+        oss << " !(";
+        not_expr->operand->accept(this);
+        oss << ')';
     }
 
     void CodeGenCPP::visit(mir::MulExpr::Ptr expr) {

--- a/src/midend/mir.cpp
+++ b/src/midend/mir.cpp
@@ -338,6 +338,50 @@ namespace graphit {
             return node;
         }
 
+        void AndExpr::copy(MIRNode::Ptr node) {
+            const auto expr = mir::to<AndExpr>(node);
+            BinaryExpr::copy(expr);
+        }
+
+        MIRNode::Ptr AndExpr::cloneNode() {
+            const auto node = std::make_shared<AndExpr>();
+            node->copy(shared_from_this());
+            return node;
+        }
+
+        void OrExpr::copy(MIRNode::Ptr node) {
+            const auto expr = mir::to<OrExpr>(node);
+            BinaryExpr::copy(expr);
+        }
+
+        MIRNode::Ptr OrExpr::cloneNode() {
+            const auto node = std::make_shared<OrExpr>();
+            node->copy(shared_from_this());
+            return node;
+        }
+
+        void XorExpr::copy(MIRNode::Ptr node) {
+            const auto expr = mir::to<XorExpr>(node);
+            BinaryExpr::copy(expr);
+        }
+
+        MIRNode::Ptr XorExpr::cloneNode() {
+            const auto node = std::make_shared<XorExpr>();
+            node->copy(shared_from_this());
+            return node;
+        }
+
+        void NotExpr::copy(MIRNode::Ptr node) {
+            const auto expr = mir::to<NotExpr>(node);
+            operand = expr->operand->clone<Expr>();
+        }
+
+        MIRNode::Ptr NotExpr::cloneNode() {
+            const auto node = std::make_shared<NotExpr>();
+            node->copy(shared_from_this());
+            return node;
+        }
+
         void AddExpr::copy(MIRNode::Ptr node) {
             const auto expr = mir::to<AddExpr>(node);
             BinaryExpr::copy(expr);

--- a/src/midend/mir_emitter.cpp
+++ b/src/midend/mir_emitter.cpp
@@ -651,7 +651,7 @@ namespace graphit {
 
         const auto func_name = func_decl->name->ident;
         mir_func_decl->name = func_name;
-        // Copy the type from the fir node to the mir node (for external/internal type)
+        // Copy the type from the fir node to the mir node (for external/internal type) 
         mir_func_decl->type = getMirFuncDeclType(func_decl->type);
 
 	if (mir_func_decl->type == mir::FuncDecl::Type::INTERNAL) {

--- a/src/midend/mir_emitter.cpp
+++ b/src/midend/mir_emitter.cpp
@@ -344,6 +344,33 @@ namespace graphit {
         retExpr = mir_var_expr;
     }
 
+    void MIREmitter::visit(fir::AndExpr::Ptr fir_expr) {
+        auto mir_expr = std::make_shared<mir::AndExpr>();
+        mir_expr->lhs = emitExpr(fir_expr->lhs);
+        mir_expr->rhs = emitExpr(fir_expr->rhs);
+        retExpr = mir_expr;
+    };
+
+    void MIREmitter::visit(fir::OrExpr::Ptr fir_expr) {
+        auto mir_expr = std::make_shared<mir::OrExpr>();
+        mir_expr->lhs = emitExpr(fir_expr->lhs);
+        mir_expr->rhs = emitExpr(fir_expr->rhs);
+        retExpr = mir_expr;
+    };
+
+    void MIREmitter::visit(fir::XorExpr::Ptr fir_expr) {
+        auto mir_expr = std::make_shared<mir::XorExpr>();
+        mir_expr->lhs = emitExpr(fir_expr->lhs);
+        mir_expr->rhs = emitExpr(fir_expr->rhs);
+        retExpr = mir_expr;
+    };
+
+    void MIREmitter::visit(fir::NotExpr::Ptr not_expr) {
+        auto mir_expr = std::make_shared<mir::NotExpr>();
+        mir_expr->operand = emitExpr(not_expr->operand);
+        retExpr = mir_expr;
+    }
+
     void MIREmitter::visit(fir::AddExpr::Ptr fir_expr) {
         auto mir_expr = std::make_shared<mir::AddExpr>();
         mir_expr->lhs = emitExpr(fir_expr->lhs);
@@ -624,7 +651,7 @@ namespace graphit {
 
         const auto func_name = func_decl->name->ident;
         mir_func_decl->name = func_name;
-        // Copy the type from the fir node to the mir node (for external/internal type) 
+        // Copy the type from the fir node to the mir node (for external/internal type)
         mir_func_decl->type = getMirFuncDeclType(func_decl->type);
 
 	if (mir_func_decl->type == mir::FuncDecl::Type::INTERNAL) {

--- a/src/midend/mir_rewriter.cpp
+++ b/src/midend/mir_rewriter.cpp
@@ -107,6 +107,23 @@ namespace graphit {
             visitNaryExpr(expr);
         }
 
+        void MIRRewriter::visit(AndExpr::Ptr expr) {
+            visitBinaryExpr(expr);
+        }
+
+        void MIRRewriter::visit(OrExpr::Ptr expr) {
+            visitBinaryExpr(expr);
+        }
+
+        void MIRRewriter::visit(XorExpr::Ptr expr) {
+            visitBinaryExpr(expr);
+        }
+
+        void MIRRewriter::visit(NotExpr::Ptr expr) {
+            expr->operand = rewrite<mir::Expr>(expr->operand);
+            node = expr;
+        }
+
         void MIRRewriter::visit(AddExpr::Ptr expr) {
             visitBinaryExpr(expr);
         }

--- a/src/midend/mir_visitor.cpp
+++ b/src/midend/mir_visitor.cpp
@@ -61,7 +61,7 @@ namespace graphit {
                 label_scope_.unscope();
             }
         }
-
+      
         void MIRVisitor::visit(PrintStmt::Ptr stmt) {
             stmt->expr->accept(this);
         }
@@ -103,7 +103,7 @@ namespace graphit {
             visitNaryExpr(expr);
         }
 
-        void MIRVisitor::visit(AndExpr::Ptr expr) {
+	void MIRVisitor::visit(AndExpr::Ptr expr) {
             visitBinaryExpr(expr);
         }
 

--- a/src/midend/mir_visitor.cpp
+++ b/src/midend/mir_visitor.cpp
@@ -61,7 +61,7 @@ namespace graphit {
                 label_scope_.unscope();
             }
         }
-      
+
         void MIRVisitor::visit(PrintStmt::Ptr stmt) {
             stmt->expr->accept(this);
         }
@@ -101,6 +101,22 @@ namespace graphit {
 
         void MIRVisitor::visit(EqExpr::Ptr expr) {
             visitNaryExpr(expr);
+        }
+
+        void MIRVisitor::visit(AndExpr::Ptr expr) {
+            visitBinaryExpr(expr);
+        }
+
+        void MIRVisitor::visit(OrExpr::Ptr expr) {
+            visitBinaryExpr(expr);
+        }
+
+        void MIRVisitor::visit(XorExpr::Ptr expr) {
+            visitBinaryExpr(expr);
+        }
+
+        void MIRVisitor::visit(std::shared_ptr<NotExpr> expr) {
+            expr->operand->accept(this);
         }
 
         void MIRVisitor::visit(AddExpr::Ptr expr) {

--- a/test/input/simple_boolean_op.gt
+++ b/test/input/simple_boolean_op.gt
@@ -1,0 +1,13 @@
+func main()
+    var x : bool = true;
+    var y : bool = false;
+    if x and (not y)
+       print "x is true and y is false";
+    end
+    if x xor y
+       print "either x or y is true";
+    end
+    if x or y
+       print "x or y or both are true";
+    end       
+end

--- a/test/python/test.py
+++ b/test/python/test.py
@@ -399,6 +399,9 @@ class TestGraphitCompiler(unittest.TestCase):
     def test_vertexset_filter_const(self):
         self.expect_output_val("vertexset_filter_const.gt", 2)
 
+    def test_simple_boolean_op(self):
+        self.basic_compile_test("simple_boolean_op.gt")
+
 if __name__ == '__main__':
     unittest.main()
     # used for enabling a specific test


### PR DESCRIPTION
Boolean operators (`and`, `or`, `xor`, and `not`) were implemented in the frontend IR, but dropped when lowered to the midend IR. This adds support for the mentioned boolean operators to the midend IR and backend code generation. 