### PR TITLE
Fixed uint issue

### DIFF
--- a/src/frontend/parser.cpp
+++ b/src/frontend/parser.cpp
@@ -1579,6 +1579,7 @@ namespace graphit {
                 break;
             case Token::Type::DOUBLE:
             case Token::Type::INT:
+            case Token::Type::UINT:
             case Token::Type::FLOAT:
             case Token::Type::BOOL:
             case Token::Type::COMPLEX:

--- a/test/c++/backend_test.cpp
+++ b/test/c++/backend_test.cpp
@@ -60,6 +60,11 @@ TEST_F(BackendTest, SimpleVarDecl) {
     EXPECT_EQ (0, basicTest(is));
 }
 
+
+TEST_F(BackendTest, UINTDecl ) {
+    istringstream is("const a : uint = 3 + 4;");
+    EXPECT_EQ (0,  basicTest(is));
+}
 TEST_F(BackendTest, SimpleDoubleVarDecl) {
     istringstream is("const a : double = 3; \n func main()  end");
     EXPECT_EQ (0, basicTest(is));

--- a/test/c++/frontend_test.cpp
+++ b/test/c++/frontend_test.cpp
@@ -51,7 +51,10 @@ TEST_F(FrontendTest, SimpleVarDecl ) {
     EXPECT_EQ (0,  basicTest(is));
 }
 
-
+TEST_F(FrontendTest, UINTVarDecl ) {
+    istringstream is("const a : uint = 3 + 4;");
+    EXPECT_EQ (0,  basicTest(is));
+}
 TEST_F(FrontendTest, SimpleFunctionDecl ) {
     istringstream is("func add(a : int, b: int) -> c : int  end");
     EXPECT_EQ (0,  basicTest(is));

--- a/test/c++/midend_test.cpp
+++ b/test/c++/midend_test.cpp
@@ -54,6 +54,10 @@ TEST_F(MidendTest, SimpleVarDecl ) {
 }
 
 
+TEST_F(MidendTest, UINTDecl ) {
+    istringstream is("const a : uint = 3 + 4;");
+    EXPECT_EQ (0 , basicTest(is));
+}
 //tests mid end
 TEST_F(MidendTest, SimpleFunctionDecl) {
     istringstream is("func add(a : int, b: int) -> c : int  end");


### PR DESCRIPTION
Previously, `const a: uint = 4` kind of declaration didn't work. Now the compiler recognizes it.