### PR TITLE
[swarm_intrinics] Add manual task boundary annotation.

### DIFF
--- a/src/runtime_lib/swarm_intrinsics.h
+++ b/src/runtime_lib/swarm_intrinsics.h
@@ -5,13 +5,16 @@
 #include "pls/pls_api.h"
 #include "pls/algorithm.h"
 #include "thread_local_queues.h"
+#include "scc/hacks.h"
 
 #include "infra_swarm/graph.h"
 #define SWARM_FUNC_ATTRIBUTES __attribute__((noinline, swarmify, assertswarmified))
 namespace swarm_runtime {
 template <typename T>
 bool sum_reduce(T& dst, T src) {
-	dst += src;
+	SCC_HACK_TASK({
+		dst += src;
+	});
 	return true;
 }	
 


### PR DESCRIPTION
This commit relies on updates to SCC and related headers to achieve good
performance.  Please pull the latest changes to SCC and the Swarm
benchmarks repo and rebuild SCC before using this commit.

Each iteration of the hottest loop in pagerank traverse an edge, which
involves two sorts of things:
1.) Reading from a bunch of locations in memory find the src node ID,
    dest node ID, and the amount of the contribution from the src.
    These data structures are effectively read-only (not being updated)
    during this period of execution.
2.) Performing a read-modify-write on the the dest node's value.

While 1 accounts for more of the execution time and should be highly
parallelizable, 2 sometimes generates conflicts by accessing frequently
written cache lines.  During a conflict, the entire loop-iteration task
would be aborted.  Moreover, because the task needs to dynamically
obtain the destination node ID, which is not an induction variable and
is not known until after the task starts execution, the task cannot have
a spatial hint.  The manual task annotation has two benefits:
A.) By putting 1 and 2 in separate tasks, 2 can abort when needed to
    resolve conflicts without aborting 1.
B.) After 1 gets the dest node ID, it can spawn 2 with a
    spatial hint, which reduces conflicts and improves performance.

See Sections II.B and V.B of the T4 paper for background.
See comments in the "scc/hacks.h" header file for more information about
how to use annotations like this:
https://github.mit.edu/swarm/benchmarks/blob/master/include/scc/hacks.h