### PR TITLE
Feature frontier reuse

### DIFF
--- a/include/graphit/midend/frontier_reuse_analysis.h
+++ b/include/graphit/midend/frontier_reuse_analysis.h
@@ -1,0 +1,38 @@
+#ifndef FRONTIER_REUSE_ANALYSIS_H
+#define FRONTIER_REUSE_ANALYSIS_H
+
+#include <graphit/midend/mir_context.h>
+#include <graphit/frontend/schedule.h>
+#include <graphit/midend/field_vector_property.h>
+#include <unordered_set>
+namespace graphit {
+class FrontierReuseAnalysis {
+public:
+	MIRContext *mir_context_;	
+	FrontierReuseAnalysis (MIRContext* mir_context): mir_context_(mir_context) {
+	}	
+	struct ReuseFindingVisitor: public mir::MIRVisitor {
+		MIRContext *mir_context_;	
+		ReuseFindingVisitor(MIRContext* mir_context): mir_context_(mir_context) {
+		}
+		using mir::MIRVisitor::visit;	
+		std::vector<mir::Stmt::Ptr> to_deletes;
+		bool is_frontier_reusable(mir::StmtBlock::Ptr, int index, std::string frontier_name); 
+		virtual void visit(mir::StmtBlock::Ptr) override;
+	};
+	struct FrontierUseFinder: public mir::MIRVisitor {
+		using mir::MIRVisitor::visit;
+		bool is_used = false;
+		std::string frontier_name;
+
+		virtual void visit(mir::VarExpr::Ptr) override;
+		virtual void visit(mir::PushEdgeSetApplyExpr::Ptr) override;
+		virtual void visit(mir::PullEdgeSetApplyExpr::Ptr) override;
+		virtual void visit(mir::EdgeSetApplyExpr::Ptr) override;
+		
+	};
+	void analyze(void);
+};
+
+}
+#endif

--- a/include/graphit/midend/mir.h
+++ b/include/graphit/midend/mir.h
@@ -921,6 +921,9 @@ namespace graphit {
             std::string scope_label_name;
             MergeReduceField::Ptr merge_reduce;
 
+
+            bool frontier_reusable = false;
+	
             typedef std::shared_ptr<EdgeSetApplyExpr> Ptr;
 
             virtual void accept(MIRVisitor *visitor) {
@@ -951,6 +954,7 @@ namespace graphit {
                 is_weighted = edgeset_apply->is_weighted;
                 is_parallel = edgeset_apply->is_parallel;
                 enable_deduplication = edgeset_apply->enable_deduplication;
+                frontier_reusable = edgeset_apply->frontier_reusable;
             }
 
             virtual void accept(MIRVisitor *visitor) {
@@ -977,6 +981,7 @@ namespace graphit {
                 is_weighted = edgeset_apply->is_weighted;
                 is_parallel = edgeset_apply->is_parallel;
                 enable_deduplication = edgeset_apply->enable_deduplication;
+                frontier_reusable = edgeset_apply->frontier_reusable;
             }
 
             virtual void accept(MIRVisitor *visitor) {

--- a/src/midend/frontier_reuse_analysis.cpp
+++ b/src/midend/frontier_reuse_analysis.cpp
@@ -1,0 +1,87 @@
+#include <graphit/midend/frontier_reuse_analysis.h>
+
+namespace graphit {
+void FrontierReuseAnalysis::analyze(void) {
+	for (auto func: mir_context_->getFunctionList()) {
+		ReuseFindingVisitor visitor(mir_context_);
+		func->accept(&visitor);	
+	}
+}
+bool FrontierReuseAnalysis::ReuseFindingVisitor::is_frontier_reusable(mir::StmtBlock::Ptr stmt_block, int index, std::string frontier_name) {
+	FrontierUseFinder finder;
+	finder.frontier_name = frontier_name;
+	index++;
+	for (int i = index; i < stmt_block->stmts->size(); i++) {
+		if (mir::isa<mir::ExprStmt>((*(stmt_block->stmts))[i])) {
+			mir::ExprStmt::Ptr expr_stmt = mir::to<mir::ExprStmt>((*(stmt_block->stmts))[i]);
+			if (mir::isa<mir::Call>(expr_stmt->expr)) {
+				mir::Call::Ptr call_expr = mir::to<mir::Call>(expr_stmt->expr);
+				if (call_expr->name == "deleteObject" && mir::isa<mir::VarExpr>(call_expr->args[0]) && mir::to<mir::VarExpr>(call_expr->args[0])->var.getName() == frontier_name) {
+					to_deletes.push_back(expr_stmt);
+					return true;
+				}
+			}	
+		}	
+		(*(stmt_block->stmts))[i]->accept(&finder);
+		if (finder.is_used)
+			return false;
+	}
+	return false;
+}
+void FrontierReuseAnalysis::ReuseFindingVisitor::visit(mir::StmtBlock::Ptr stmt_block) {
+	std::vector<mir::Stmt::Ptr> new_stmts;	
+	to_deletes.clear();
+	for (int i = 0; i < stmt_block->stmts->size(); i++) {
+		mir::Stmt::Ptr this_stmt = (*(stmt_block->stmts))[i];
+		if (mir::isa<mir::AssignStmt>(this_stmt)) {
+			mir::AssignStmt::Ptr assign_stmt = mir::to<mir::AssignStmt>(this_stmt);
+			if (mir::isa<mir::EdgeSetApplyExpr>(assign_stmt->expr)) {
+				mir::EdgeSetApplyExpr::Ptr esae = mir::to<mir::EdgeSetApplyExpr>(assign_stmt->expr);
+				if (esae->from_func != "" && !mir_context_->isFunction(esae->from_func)) {
+					std::string frontier_name = esae->from_func;
+					if (is_frontier_reusable(stmt_block, i, frontier_name)) {
+						esae->frontier_reusable = true;
+					}
+				}
+			}
+		} else if (mir::isa<mir::VarDecl>(this_stmt)) {
+			mir::VarDecl::Ptr var_decl = mir::to<mir::VarDecl>(this_stmt);
+			if (var_decl->initVal != nullptr) {
+				if (mir::isa<mir::EdgeSetApplyExpr>(var_decl->initVal)) {
+					mir::EdgeSetApplyExpr::Ptr esae = mir::to<mir::EdgeSetApplyExpr>(var_decl->initVal);
+					if (esae->from_func != "" && !mir_context_->isFunction(esae->from_func)) {
+						std::string frontier_name = esae->from_func;
+						if (is_frontier_reusable(stmt_block, i, frontier_name)) {
+							esae->frontier_reusable = true;
+						}
+					}
+				}	
+			}
+		}
+		if (std::find(to_deletes.begin(), to_deletes.end(), this_stmt) == to_deletes.end()) {
+			new_stmts.push_back(this_stmt);	
+		}
+	}	
+	(*(stmt_block->stmts)) = new_stmts;
+	mir::MIRVisitor::visit(stmt_block);
+}
+void FrontierReuseAnalysis::FrontierUseFinder::visit(mir::VarExpr::Ptr var_expr) {
+	if (var_expr->var.getName() == frontier_name)
+		is_used = true;
+}
+void FrontierReuseAnalysis::FrontierUseFinder::visit(mir::PushEdgeSetApplyExpr::Ptr pesae) {
+	mir::MIRVisitor::visit(pesae);
+	if (pesae->from_func == frontier_name)
+		is_used = true;
+}
+void FrontierReuseAnalysis::FrontierUseFinder::visit(mir::PullEdgeSetApplyExpr::Ptr pesae) {
+	mir::MIRVisitor::visit(pesae);
+	if (pesae->from_func == frontier_name)
+		is_used = true;
+}
+void FrontierReuseAnalysis::FrontierUseFinder::visit(mir::EdgeSetApplyExpr::Ptr esae) {
+	mir::MIRVisitor::visit(esae);
+	if (esae->from_func == frontier_name)
+		is_used = true;
+}
+}

--- a/src/midend/mir_lower.cpp
+++ b/src/midend/mir_lower.cpp
@@ -33,8 +33,8 @@ namespace graphit {
         //This pass needs to happen before ApplyExprLower pass because the default ReduceBeforeUpdate uses ApplyExprLower
         PriorityFeaturesLower(mir_context, schedule).lower();
 
-+       // This pass finds EdgeSetApplyExpressions that allow frontiers to be reused and removes the corresponding deletes
-+       FrontierReuseAnalysis(mir_context).analyze();
+        // This pass finds EdgeSetApplyExpressions that allow frontiers to be reused and removes the corresponding deletes
+        FrontierReuseAnalysis(mir_context).analyze();
 
         // This pass sets properties of edgeset apply expressions based on the schedules including
         // edge traversal direction: push, pull, denseforward, hybrid_dense, hybrid_denseforward

--- a/src/midend/mir_lower.cpp
+++ b/src/midend/mir_lower.cpp
@@ -33,6 +33,9 @@ namespace graphit {
         //This pass needs to happen before ApplyExprLower pass because the default ReduceBeforeUpdate uses ApplyExprLower
         PriorityFeaturesLower(mir_context, schedule).lower();
 
++       // This pass finds EdgeSetApplyExpressions that allow frontiers to be reused and removes the corresponding deletes
++       FrontierReuseAnalysis(mir_context).analyze();
+
         // This pass sets properties of edgeset apply expressions based on the schedules including
         // edge traversal direction: push, pull, denseforward, hybrid_dense, hybrid_denseforward
         // deduplication: enable / disable

--- a/src/midend/mir_lower.cpp
+++ b/src/midend/mir_lower.cpp
@@ -13,6 +13,7 @@
 #include <graphit/midend/vertex_edge_set_lower.h>
 #include <graphit/midend/merge_reduce_lower.h>
 #include <graphit/midend/priority_features_lowering.h>
+#include <graphit/midend/frontier_reuse_analysis.h>
 
 namespace graphit {
     /**


### PR DESCRIPTION
This pull request adds the frontier-reuse-analysis pass that figures out if the output frontier from an EdgeSetApplyExpr can reuse the allocation for the input frontier. This pass was originally developed for the GPU backend. 

I couldn't cherry pick the changes because the originally commit had a lot of changes specific to the GPU backend. So I checked out the changes into a separate branch. 