### PR TITLE
Fixed vertexGetSize issue

### DIFF
--- a/src/runtime_lib/intrinsics.h
+++ b/src/runtime_lib/intrinsics.h
@@ -259,7 +259,7 @@ static Graph builtin_relabel(Graph &edges) {
 }
 
 static VertexSubset<NodeID>* builtin_getNgh(Graph &edges, NodeID src){
-    auto v =  new VertexSubset<NodeID>(edges.out_degree(src));
+    auto v =  new VertexSubset<NodeID>(edges.out_degree(src), edges.out_degree(src));
     v->dense_vertex_set_ = (unsigned int*) edges.out_neigh(src).begin();
     return v;
 }

--- a/test/input/vertex_size.gt
+++ b/test/input/vertex_size.gt
@@ -1,0 +1,19 @@
+element Vertex end
+element Edge end
+const edges: edgeset{Edge}(Vertex,Vertex) = load("../test/graphs/test.el");
+const vertices: vertexset{Vertex} = edges.getVertices();
+
+const vertexSizeArray: vector{Vertex}(int) = 0;
+
+func incrementing_count(src: Vertex, dst: Vertex)
+        var src_ngs : vertexset{Vertex} = edges.getNgh(src);
+		var src_ngs_size: uint_64 = src_ngs.getVertexSetSize();
+		vertexSizeArray[src] = src_ngs_size;
+end
+
+func main()
+    edges = edges.relabel();
+	#s1# edges.apply(incrementing_count);
+	print vertexSizeArray.sum();
+end
+

--- a/test/python/test.py
+++ b/test/python/test.py
@@ -457,10 +457,13 @@ class TestGraphitCompiler(unittest.TestCase):
     def test_local_vector_call_expr(self):
         self.expect_output_val("local_vector_call_expr.gt", 20);
 
+    def test_vertex_size(self):
+        self.expect_output_val("vertex_size.gt", 7);
+
 if __name__ == '__main__':
 
     unittest.main(verbosity=2)
     #used for enabling a specific test
     # suite = unittest.TestSuite()
-    # suite.addTest(TestGraphitCompiler('test_vertexset_filter'))
+    # suite.addTest(TestGraphitCompiler('test_vertex_size'))
     # unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
This is a fix to issue #144. The problem was we were using wrong initialization of VertexSubset for builtin_getNgh.