### PR TITLE
Demonstrate splitting struct into individual scalars

### DIFF
--- a/test/swarm_tests/current_outputs/test_swarm_bc_transpose_outside.cpp
+++ b/test/swarm_tests/current_outputs/test_swarm_bc_transpose_outside.cpp
@@ -74,17 +74,19 @@ void swarm_main() {
 	}
 	in_frontier_3 = new bool [swarm_runtime::builtin_getVertices(edges)]();
 	swarm_frontier.for_each_prio([&round, &frontier_list](unsigned level, frontier_struct src_struct, auto push) {
+		auto src = src_struct.src;
+		auto frontier_insert_round_0 = src_struct.frontier_insert_round_0;
 		switch (level % 5) {
 		case 0: {
-			push(level + 1, frontier_struct{src_struct.src, src_struct.frontier_insert_round_0});
+			push(level + 1, frontier_struct{src, frontier_insert_round_0});
 			break;
 		}
 		case 1: {
-			int32_t edgeZero = edges.h_src_offsets[src_struct.src];
-			int32_t edgeLast = edges.h_src_offsets[src_struct.src+1];
+			int32_t edgeZero = edges.h_src_offsets[src];
+			int32_t edgeLast = edges.h_src_offsets[src+1];
 			for (int i = edgeZero; i < edgeLast; i++) {
 				int dst = edges.h_edge_dst[i];
-				int src = src_struct.src;
+				int src = src;
 				if (visited_vertex_filter(dst)) {
 					{
 						bool result_var4 = (bool)0;
@@ -92,7 +94,7 @@ void swarm_main() {
 						if (result_var4) {
 							if (!in_frontier_3[dst]) {
 								in_frontier_3[dst] = true;
-								push(level + 1, frontier_struct{dst, src_struct.frontier_insert_round_0});
+								push(level + 1, frontier_struct{dst, frontier_insert_round_0});
 							}
 						}
 					}
@@ -101,23 +103,23 @@ void swarm_main() {
 			break;
 		}
 		case 2: {
-			int v = src_struct.src;
+			int v = src;
 			{
 				in_frontier_3[v] = (bool)0;
 			}
 ;
-			push(level + 1, frontier_struct{src_struct.src, src_struct.frontier_insert_round_0});
+			push(level + 1, frontier_struct{src, frontier_insert_round_0});
 			break;
 		}
 		case 3: {
-			mark_visited(src_struct.src);
+			mark_visited(src);
 ;
-			push(level + 1, frontier_struct{src_struct.src, src_struct.frontier_insert_round_0});
+			push(level + 1, frontier_struct{src, frontier_insert_round_0});
 			break;
 		}
 		case 4: {
-			swarm_runtime::builtin_insert(frontier_list, src_struct.src, src_struct.frontier_insert_round_0);
-			push(level + 1, frontier_struct{src_struct.src, src_struct.frontier_insert_round_0 + 1});
+			swarm_runtime::builtin_insert(frontier_list, src, frontier_insert_round_0);
+			push(level + 1, frontier_struct{src, frontier_insert_round_0 + 1});
 			break;
 		}
 		}


### PR DESCRIPTION
This us a fairly mechanical transformation to the generated C++:
- Add local variable definitions at the top of the lambda body to extract the fields from the struct.
- Avoid any direct use of the struct elsewhere in the lambda body: replace any access to the fields of the struct to an access to the corresponding local scalar variable.

After this transformation, SCC/T4 does a slightly better job packing registers and deciding how to transfer values between the fine-grained tasks created by SCC/T4 within the lambda body, and this manages to avoid one instance of a mem_runner (i.e., transfer via the heap) for one task spawn associated with the `for` loop inside of `case 1`.