### PR TITLE
Fixed minor Codegen bug for AE

### DIFF
--- a/include/graphit/backend/codegen_gpu/codegen_gpu.h
+++ b/include/graphit/backend/codegen_gpu/codegen_gpu.h
@@ -149,6 +149,8 @@ protected:
 	virtual void visit(mir::ListAllocExpr::Ptr) override;
 
 	void genPriorityUpdateOperator(mir::PriorityUpdateOperator::Ptr); 
+	void generateDeviceToHostCopy(mir::TensorArrayReadExpr::Ptr tare);
+	void generateHostToDeviceCopy(mir::TensorArrayReadExpr::Ptr tare);
 
 };
 class CodeGenGPUHost: public CodeGenGPU {
@@ -167,8 +169,6 @@ private:
 	virtual void visit(mir::VarExpr::Ptr) override;
 
 
-	void generateDeviceToHostCopy(mir::TensorArrayReadExpr::Ptr tare);
-	void generateHostToDeviceCopy(mir::TensorArrayReadExpr::Ptr tare);
 };
 
 

--- a/src/backend/codegen_gpu/codegen_gpu.cpp
+++ b/src/backend/codegen_gpu/codegen_gpu.cpp
@@ -1467,12 +1467,22 @@ void CodeGenGPU::visit(mir::WhileStmt::Ptr while_stmt) {
 		}
 		return;
 	}
+
+	ExtractReadWriteSet extractor(mir_context_);
+	while_stmt->cond->accept(&extractor);
+	
 	printIndent();
 	oss << "while (";
 	while_stmt->cond->accept(this);
 	oss << ") {" << std::endl;
 	indent();
+	for (auto tare: extractor.write_set) {
+		generateHostToDeviceCopy(tare);
+	}
 	while_stmt->body->accept(this);
+	for (auto tare: extractor.read_set) {
+		generateDeviceToHostCopy(tare);
+	}
 	dedent();
 	printIndent();
 	oss << "}" << std::endl;
@@ -1690,7 +1700,7 @@ void CodeGenGPU::visit(mir::VertexSetAllocExpr::Ptr vsae) {
 		vsae->size_expr->accept(this);
 	oss << ")";
 }
-void CodeGenGPUHost::generateDeviceToHostCopy(mir::TensorArrayReadExpr::Ptr tare) {
+void CodeGenGPU::generateDeviceToHostCopy(mir::TensorArrayReadExpr::Ptr tare) {
 	printIndent();
 	mir::Var target = mir::to<mir::VarExpr>(tare->target)->var;
 	std::string var_name = target.getName();
@@ -1703,7 +1713,7 @@ void CodeGenGPUHost::generateDeviceToHostCopy(mir::TensorArrayReadExpr::Ptr tare
 	oss << "), cudaMemcpyDeviceToHost);" << std::endl;	
 	
 }
-void CodeGenGPUHost::generateHostToDeviceCopy(mir::TensorArrayReadExpr::Ptr tare) {
+void CodeGenGPU::generateHostToDeviceCopy(mir::TensorArrayReadExpr::Ptr tare) {
 	printIndent();
 	mir::Var target = mir::to<mir::VarExpr>(tare->target)->var;
 	std::string var_name = target.getName();


### PR DESCRIPTION
There was a minor bug with the code generator where if the condition for the `WhileStmt` requires data copy between HOST and GPU, it wasn't being copied. This bug surfaced during AE for the CGO22 BuilDSL paper. 

This fix uses the existing ExtractReadWriteSet pass and invokes it before generating the condition. 